### PR TITLE
Fix to add currencyPair to orderbook objects

### DIFF
--- a/lib/api/push.js
+++ b/lib/api/push.js
@@ -304,7 +304,7 @@ api.prototype.orderTrade = function(currencyPair, callback, allowBatches) {
 
                 // Object for parsed update data
                 var updateParsed = {};
-
+                updateParsed["currencyPair"] = currencyPair;
                 // Store raw update data and type
                 updateParsed["raw"] = update;
                 updateParsed["updateType"] = update.type;


### PR DESCRIPTION
Fix to add currencyPair to orderbook objects, this allows more complex analysis of the data since you do not need a unique function per pair
