### PR TITLE
PaymentId request parameter only set on withdrawals when it is populated.

### DIFF
--- a/lib/api/trading.js
+++ b/lib/api/trading.js
@@ -450,7 +450,7 @@ TradingWrapper.prototype.withdraw = function(currency, amount, address, paymentI
     };
 
     //only set paymentId if it is not null, otherwise Poloniex will return an error for a blank param
-    if(paymentId != null) {
+    if (paymentId != null) {
         opts.paymentId = paymentId;
     }
 

--- a/lib/api/trading.js
+++ b/lib/api/trading.js
@@ -446,9 +446,13 @@ TradingWrapper.prototype.withdraw = function(currency, amount, address, paymentI
     var opts = {
         "currency": currency,
         "amount": amount,
-        "address": address,
-        "paymentId": paymentId
+        "address": address
     };
+
+    //only set paymentId if it is not null, otherwise Poloniex will return an error for a blank param
+    if(paymentId != null) {
+        opts.paymentId = paymentId;
+    }
 
     // Send withdraw query
     sendQuery(this, "withdraw", opts, (err, response) => {


### PR DESCRIPTION
PaymentId should only be set for withdrawals if the parameter is populated, otherwise, Poloniex will return an error if the request parameter is blank.
