### PR TITLE
Use hyperquest/hypersponse instead of request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+/test/config.js

--- a/lib/api/PublicWrapper.js
+++ b/lib/api/PublicWrapper.js
@@ -17,7 +17,8 @@
 "use strict";
 
 // Import third-party modules
-const request = require("request");
+const hyperquest = require("hyperquest");
+const hypersponse = require("hypersponse");
 const url = require("url");
 
 // Import local modules
@@ -58,7 +59,7 @@ function sendQuery(api, command, params) {
 
     // Build options for request
     let opts = {
-        "url": url.format(queryUrl),
+        "uri": url.format(queryUrl),
         "method": "GET",
         "headers": {
             "User-Agent": REQUEST_USER_AGENT
@@ -68,7 +69,7 @@ function sendQuery(api, command, params) {
     // Return a promise for the response data
     return new Promise((resolve, reject) => {
         // Send request to Poloniex
-        request(opts, (error, response, body) => {
+        hypersponse(hyperquest(opts), (error, response, body) => {
             // If request was successful
             if (!error && response && response.statusCode == 200) {
                 // Parsed response body

--- a/lib/api/PublicWrapper.js
+++ b/lib/api/PublicWrapper.js
@@ -17,8 +17,7 @@
 "use strict";
 
 // Import third-party modules
-const hyperquest = require("hyperquest");
-const hypersponse = require("hypersponse");
+const jsonist = require("jsonist");
 const url = require("url");
 
 // Import local modules
@@ -58,9 +57,8 @@ function sendQuery(api, command, params) {
     queryUrl.query = query;
 
     // Build options for request
+    let uri = url.format(queryUrl);
     let opts = {
-        "uri": url.format(queryUrl),
-        "method": "GET",
         "headers": {
             "User-Agent": REQUEST_USER_AGENT
         }
@@ -69,19 +67,9 @@ function sendQuery(api, command, params) {
     // Return a promise for the response data
     return new Promise((resolve, reject) => {
         // Send request to Poloniex
-        hypersponse(hyperquest(opts), (error, response, body) => {
+        jsonist.get(uri, opts, (error, bodyParsed, response) => {
             // If request was successful
             if (!error && response && response.statusCode == 200) {
-                // Parsed response body
-                let bodyParsed;
-
-                // Try to parse response body as JSON
-                try {
-                    bodyParsed = JSON.parse(body);
-                } catch (e) {
-                    reject({msg: "Unable to parse response body: " + e, _body: body});
-                    return;
-                }
 
                 // Enforce type of returned data (see issue #16)
                 if (bodyParsed === null || typeof bodyParsed !== "object") {

--- a/lib/api/TradingWrapper.js
+++ b/lib/api/TradingWrapper.js
@@ -18,7 +18,8 @@
 
 // Import third-party modules
 const crypto = require("crypto");
-const request = require("request");
+const hyperquest = require("hyperquest");
+const hypersponse = require("hypersponse");
 const url = require("url");
 
 // Import local modules
@@ -85,7 +86,7 @@ function sendQuery(api, command, params) {
 
     // Build options for request
     let opts = {
-        "url": POLONIEX_TRADING_URL,
+        "uri": POLONIEX_TRADING_URL,
         "method": "POST",
         "headers": {
             "User-Agent": REQUEST_USER_AGENT,
@@ -99,7 +100,7 @@ function sendQuery(api, command, params) {
     // Return a promise for the response data
     return new Promise((resolve, reject) => {
         // Send request to Poloniex
-        request(opts, (error, response, body) => {
+        hypersponse(hyperquest(opts), (error, response, body) => {
             // If request was successful
             if (!error && response && response.statusCode == 200) {
                 // Parsed response body

--- a/lib/api/TradingWrapper.js
+++ b/lib/api/TradingWrapper.js
@@ -18,8 +18,7 @@
 
 // Import third-party modules
 const crypto = require("crypto");
-const hyperquest = require("hyperquest");
-const hypersponse = require("hypersponse");
+const request = require("request");
 const url = require("url");
 
 // Import local modules
@@ -86,7 +85,7 @@ function sendQuery(api, command, params) {
 
     // Build options for request
     let opts = {
-        "uri": POLONIEX_TRADING_URL,
+        "url": POLONIEX_TRADING_URL,
         "method": "POST",
         "headers": {
             "User-Agent": REQUEST_USER_AGENT,
@@ -100,7 +99,7 @@ function sendQuery(api, command, params) {
     // Return a promise for the response data
     return new Promise((resolve, reject) => {
         // Send request to Poloniex
-        hypersponse(hyperquest(opts), (error, response, body) => {
+        request(opts, (error, response, body) => {
             // If request was successful
             if (!error && response && response.statusCode == 200) {
                 // Parsed response body

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "autobahn": "^0.10.1",
     "crypto": "^0.0.3",
-    "hyperquest": "^2.1.2",
-    "hypersponse": "^1.0.3",
+    "jsonist": "^1.3.0",
+    "request": "^2.79.0",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "autobahn": "^0.10.1",
     "crypto": "^0.0.3",
-    "request": "^2.72.0",
+    "hyperquest": "^2.1.2",
+    "hypersponse": "^1.0.3",
     "url": "^0.11.0"
   },
   "devDependencies": {

--- a/test/config-sample.js
+++ b/test/config-sample.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = {
+    "key": "",
+    "secret": ""
+};

--- a/test/test-lib-api-TradingWrapper.js
+++ b/test/test-lib-api-TradingWrapper.js
@@ -14,4 +14,77 @@
  *
  */
 
+/*global assert describe it beforeEach*/
+
 "use strict";
+
+// Import main module
+const polo = require("./../");
+const config = require("./config.js");
+
+// Delay between online tests
+const DELAY_ONLINE_TESTS = 500;
+
+// Get TradingWrapper class
+const TradingWrapper = polo.TradingWrapper;
+
+// Create new trading wrapper instance
+const poloTrading = new TradingWrapper(config.key, config.secret);
+
+describe("TradingWrapper", function() {
+    it("should be a function", function(done) {
+        assert(typeof TradingWrapper === "function");
+        done();
+    });
+    it("should implement Poloniex's returnCompleteBalances command", function(done) {
+        assert(typeof poloTrading.returnCompleteBalances !== "undefined");
+        done();
+    });
+    describe(`online (${DELAY_ONLINE_TESTS}ms delays)`, function() {
+        // Redefine "slow" for Internet communication
+        this.slow(500);
+
+        // General checks for any public API response
+        function checkGeneral(res) {
+            assert(typeof res !== "undefined");
+            assert(typeof res.error === "undefined");
+            return res;
+        }
+
+        // Specific checks for any one response (may be redefined)
+        let checkSpecific = function(res) {
+            return res;
+        };
+
+        // General function for promise testing
+        function testPromise(res) {
+            return checkGeneral(res) && checkSpecific(res);
+        }
+
+        // General function for callback testing
+        function testCallback(done) {
+            return function(err, res) {
+                if (err) {
+                    throw err;
+                }
+                checkGeneral(res);
+                checkSpecific(res);
+                done();
+            };
+        }
+
+        // Apply a delay before each test (to avoid overtaxing Poloniex servers)
+        beforeEach(function(done) {
+            setTimeout(done, DELAY_ONLINE_TESTS);
+        });
+
+        describe("returnCompleteBalances", function() {
+            it("should return complete balances for user (via promise)", function() {
+                return poloTrading.returnCompleteBalances().then(testPromise);
+            });
+            it("should return complete balances for user (via callback)", function(done) {
+                poloTrading.returnCompleteBalances(testCallback(done));
+            });
+        });
+    });
+});


### PR DESCRIPTION
The default `request` module is broken. Use http as a streaming protocol.
Replacing request with hyperquest solves a lot of esockettimeout error et al.
See: https://github.com/substack/hyperquest